### PR TITLE
Fix search error after joining match

### DIFF
--- a/FutbolYa.WebAPI/Models/Usuario.cs
+++ b/FutbolYa.WebAPI/Models/Usuario.cs
@@ -1,4 +1,6 @@
-﻿namespace FutbolYa.WebAPI.Models
+using System.Text.Json.Serialization;
+
+namespace FutbolYa.WebAPI.Models
 {
     public class Usuario
     {
@@ -13,6 +15,7 @@
         public List<Calificacion> Calificaciones { get; set; } = new();
 
         // ✅ Relación muchos a muchos
+        [JsonIgnore]
         public ICollection<Partido> Partidos { get; set; } = new List<Partido>();
     }
 }


### PR DESCRIPTION
## Summary
- prevent object cycle when listing `Partidos` by adding `[JsonIgnore]` on `Usuario.Partidos`

## Testing
- `dotnet build FutbolYa.WebAPI.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851e57024688331bf4f09cf07019353