### PR TITLE
feat: agregar reservas completas (creación, unión, vista agenda, cont…

### DIFF
--- a/FutbolYa.WebAPI/Controllers/ReservasController.cs
+++ b/FutbolYa.WebAPI/Controllers/ReservasController.cs
@@ -1,0 +1,298 @@
+﻿using FutbolYa.WebAPI.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System.Security.Claims;
+using FutbolYa.WebAPI.Helpers;
+
+
+namespace FutbolYa.WebAPI.Controllers
+{
+    [Authorize]
+    [ApiController]
+    [Route("api/[controller]")]
+    public class ReservasController : ControllerBase
+    {
+        private readonly AppDbContext _context;
+
+        public ReservasController(AppDbContext context)
+        {
+            _context = context;
+        }
+
+        // POST: api/reservas
+        [HttpPost]
+        public async Task<IActionResult> Crear([FromBody] ReservaDTO dto)
+        {
+            var userId = int.Parse(User.FindFirst(ClaimTypes.NameIdentifier).Value);
+            var userRol = User.FindFirst(ClaimTypes.Role)?.Value;
+
+            var usuario = await _context.Usuarios.FindAsync(userId);
+            if (usuario == null)
+                return Unauthorized("Usuario no encontrado");
+
+            var cancha = await _context.Canchas.FindAsync(dto.CanchaId);
+            if (cancha == null) return NotFound("Cancha no encontrada");
+
+            // Validación: máximo 60 minutos
+            if (dto.DuracionMinutos > 60)
+                return BadRequest("Duración máxima permitida es 60 minutos");
+
+            // Verifica si hay conflicto de horario
+            var fin = dto.FechaHora.AddMinutes(dto.DuracionMinutos);
+            var conflicto = await _context.Reservas.AnyAsync(r =>
+                r.CanchaId == dto.CanchaId &&
+                dto.FechaHora < r.FechaHora.AddMinutes(r.DuracionMinutos) &&
+                fin > r.FechaHora
+            );
+            if (conflicto) return BadRequest("Ya hay una reserva en ese horario");
+
+            var reserva = new Reserva
+            {
+                CanchaId = dto.CanchaId,
+                FechaHora = dto.FechaHora,
+                DuracionMinutos = dto.DuracionMinutos,
+                ClienteNombre = userRol == "jugador" ? usuario.Nombre : dto.ClienteNombre,
+                ClienteTelefono = userRol == "jugador" ? "No informado" : dto.ClienteTelefono,
+                ClienteEmail = userRol == "jugador" ? usuario.Correo : dto.ClienteEmail,
+                EsFrecuente = dto.EsFrecuente,
+                EstadoPago = dto.EstadoPago,
+                Observaciones = dto.Observaciones,
+                UsuarioEstablecimientoId = userRol == "establecimiento"
+                    ? userId
+                    : cancha.UsuarioEstablecimientoId
+            };
+
+            _context.Reservas.Add(reserva);
+            await _context.SaveChangesAsync();
+
+            if (userRol == "jugador")
+            {
+                _context.ReservaUsuarios.Add(new ReservaUsuario
+                {
+                    ReservaId = reserva.Id,
+                    UsuarioId = userId
+                });
+                await _context.SaveChangesAsync();
+            }
+
+            return Ok(new { mensaje = "Reserva creada", reserva.Id });
+        }
+
+
+        // GET: api/reservas/mis
+        [HttpGet("mis")]
+        public async Task<IActionResult> VerMisReservas()
+        {
+            var userId = int.Parse(User.FindFirst(ClaimTypes.NameIdentifier).Value);
+            var userRol = User.FindFirst(ClaimTypes.Role)?.Value;
+
+            if (userRol == "establecimiento")
+            {
+                var reservas = await _context.Reservas
+                    .Include(r => r.Cancha)
+                    .Where(r => r.UsuarioEstablecimientoId == userId)
+                    .ToListAsync();
+
+                var resultado = reservas.Select(r => new
+                {
+                    r.Id,
+                    r.CanchaId,
+                    CanchaNombre = r.Cancha.Nombre,
+                    Hora = r.FechaHora.ToHoraFormato(),
+                    r.DuracionMinutos,
+                    r.ClienteNombre,
+                    r.ClienteTelefono,
+                    r.ClienteEmail,
+                    r.EstadoPago,
+                    r.Observaciones
+                });
+                return Ok(resultado);
+
+            }
+
+            // Jugador: buscar reservas donde figura como cliente (opcional)
+            var jugador = await _context.Usuarios.FindAsync(userId);
+            var reservasCliente = await _context.Reservas
+                .Where(r => r.ClienteEmail == jugador.Correo)
+                .ToListAsync();
+
+            return Ok(reservasCliente);
+        }
+
+        [HttpGet("cancha/{id}")]
+        [Authorize(Roles = "establecimiento")]
+        public async Task<IActionResult> VerPorCancha(int id)
+        {
+            var userId = int.Parse(User.FindFirst(ClaimTypes.NameIdentifier).Value);
+
+            var cancha = await _context.Canchas
+    .FirstOrDefaultAsync(c => c.Id == id && c.UsuarioEstablecimientoId == userId);
+
+            if (cancha == null)
+            {
+                return Unauthorized("No podés ver las reservas de una cancha que no es tuya o no existe");
+            }
+
+
+
+            var reservas = await _context.Reservas
+                .Where(r => r.CanchaId == id)
+                .Include(r => r.Cancha)
+                .ToListAsync();
+
+            var resultado = reservas.Select(r => new
+            {
+                r.Id,
+                r.CanchaId,
+                CanchaNombre = r.Cancha.Nombre,
+                Hora = r.FechaHora.ToHoraFormato(),
+                r.DuracionMinutos,
+                r.ClienteNombre,
+                r.EstadoPago,
+                r.Observaciones
+            });
+
+            return Ok(resultado);
+        }
+
+
+        // GET: api/reservas/agenda
+        [HttpGet("agenda")]
+        [Authorize(Roles = "establecimiento")]
+        public async Task<IActionResult> VerAgenda([FromQuery] DateTime? fecha, [FromQuery] bool semana = false, [FromQuery] int? canchaId = null)
+        {
+            var userId = int.Parse(User.FindFirst(ClaimTypes.NameIdentifier).Value);
+            var dia = fecha?.Date ?? DateTime.Today;
+
+            var inicio = semana ? dia.StartOfWeek(DayOfWeek.Monday) : dia;
+            var fin = semana ? inicio.AddDays(7) : dia.AddDays(1);
+
+            var query = _context.Reservas
+                .Include(r => r.Cancha)
+                .Where(r => r.UsuarioEstablecimientoId == userId &&
+                            r.FechaHora >= inicio &&
+                            r.FechaHora < fin);
+
+            if (canchaId.HasValue)
+                query = query.Where(r => r.CanchaId == canchaId.Value);
+
+            var reservas = await query.OrderBy(r => r.FechaHora).ToListAsync();
+
+            var resultado = reservas.Select(r => new
+            {
+                Cancha = r.Cancha.Nombre,
+                Hora = r.FechaHora.ToHoraFormato(),
+                r.DuracionMinutos,
+                Cliente = r.ClienteNombre,
+                Estado = r.EstadoPago
+            });
+
+            return Ok(resultado);
+        }
+
+
+        // PUT: api/reservas/5
+        [HttpPut("{id}")]
+        [Authorize(Roles = "establecimiento")]
+        public async Task<IActionResult> Editar(int id, [FromBody] ReservaDTO dto)
+        {
+            var reserva = await _context.Reservas.FindAsync(id);
+            if (reserva == null) return NotFound("Reserva no encontrada");
+
+            reserva.EstadoPago = dto.EstadoPago;
+            reserva.Observaciones = dto.Observaciones;
+            await _context.SaveChangesAsync();
+
+            return Ok("Reserva actualizada");
+        }
+
+        // POST: api/reservas/5/unirse
+        [HttpPost("{id}/unirse")]
+        [Authorize(Roles = "jugador")]
+        public async Task<IActionResult> Unirse(int id)
+        {
+            var userId = int.Parse(User.FindFirst(ClaimTypes.NameIdentifier)?.Value);
+            var reserva = await _context.Reservas
+                .Include(r => r.Jugadores)
+                .ThenInclude(j => j.Usuario)
+                .Include(r => r.Cancha)
+                .FirstOrDefaultAsync(r => r.Id == id);
+
+            if (reserva == null)
+                return NotFound("Reserva no encontrada");
+
+            // Verifica si ya está unido
+            if (reserva.Jugadores.Any(j => j.UsuarioId == userId))
+                return BadRequest("Ya estás unido a esta reserva");
+
+            // Verifica límite según tipo de cancha
+            int capacidadMaxima = reserva.Cancha.Tipo switch
+            {
+                "F5" => 10,
+                "F7" => 14,
+                "F11" => 22,
+                _ => 10 // valor por defecto si no matchea
+            };
+
+            if (reserva.Jugadores.Count >= capacidadMaxima)
+                return BadRequest("La reserva ya alcanzó el máximo de jugadores");
+
+            // Agrega jugador a la reserva
+            var nuevoJugador = new ReservaUsuario
+            {
+                ReservaId = id,
+                UsuarioId = userId
+            };
+
+            _context.ReservaUsuarios.Add(nuevoJugador);
+            await _context.SaveChangesAsync();
+
+            return Ok("Te uniste correctamente a la reserva");
+        }
+
+        // GET: api/reservas/5/jugadores
+        [HttpGet("{id}/jugadores")]
+        [Authorize(Roles = "establecimiento")]
+        public async Task<IActionResult> VerJugadores(int id)
+        {
+            var reserva = await _context.Reservas
+                .Include(r => r.Jugadores)
+                    .ThenInclude(ru => ru.Usuario)
+                .FirstOrDefaultAsync(r => r.Id == id);
+
+            if (reserva == null)
+                return NotFound("Reserva no encontrada");
+
+            var jugadores = reserva.Jugadores.Select(j => new
+            {
+                j.Usuario.Id,
+                j.Usuario.Nombre,
+                j.Usuario.Correo,
+                j.Usuario.Posicion,
+                j.Usuario.FotoPerfil
+            });
+
+            return Ok(jugadores);
+        }
+
+
+        // DELETE: api/reservas/5/salir
+        [HttpDelete("{id}/salir")]
+        public async Task<IActionResult> Salir(int id)
+        {
+            var userId = int.Parse(User.FindFirst(ClaimTypes.NameIdentifier).Value);
+            var reserva = await _context.Reservas.FindAsync(id);
+            if (reserva == null) return NotFound("Reserva no encontrada");
+
+            if (User.IsInRole("establecimiento") || reserva.ClienteNombre.Contains(userId.ToString()))
+            {
+                _context.Reservas.Remove(reserva);
+                await _context.SaveChangesAsync();
+                return Ok("Reserva cancelada");
+            }
+
+            return Forbid("No estás autorizado para cancelar esta reserva");
+        }
+    }
+}

--- a/FutbolYa.WebAPI/Helpers/TimeExtensions.cs
+++ b/FutbolYa.WebAPI/Helpers/TimeExtensions.cs
@@ -1,0 +1,16 @@
+﻿namespace FutbolYa.WebAPI.Helpers
+{
+    public static class TimeExtensions
+    {
+        public static string ToHoraFormato(this DateTime fechaHora)
+        {
+            return fechaHora.ToString("HH:mm:ss");
+        }
+        public static DateTime StartOfWeek(this DateTime dt, DayOfWeek startOfWeek)
+        {
+            int diff = (7 + (dt.DayOfWeek - startOfWeek)) % 7;
+            return dt.AddDays(-1 * diff).Date;
+        }
+
+    }
+}

--- a/FutbolYa.WebAPI/Migrations/20250718013656_AddReservas.Designer.cs
+++ b/FutbolYa.WebAPI/Migrations/20250718013656_AddReservas.Designer.cs
@@ -4,6 +4,7 @@ using FutbolYa.WebAPI.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace FutbolYa.WebAPI.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250718013656_AddReservas")]
+    partial class AddReservas
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -197,21 +199,6 @@ namespace FutbolYa.WebAPI.Migrations
                     b.ToTable("Reservas");
                 });
 
-            modelBuilder.Entity("FutbolYa.WebAPI.Models.ReservaUsuario", b =>
-                {
-                    b.Property<int>("ReservaId")
-                        .HasColumnType("int");
-
-                    b.Property<int>("UsuarioId")
-                        .HasColumnType("int");
-
-                    b.HasKey("ReservaId", "UsuarioId");
-
-                    b.HasIndex("UsuarioId");
-
-                    b.ToTable("ReservaUsuarios");
-                });
-
             modelBuilder.Entity("FutbolYa.WebAPI.Models.Usuario", b =>
                 {
                     b.Property<int>("Id")
@@ -393,25 +380,6 @@ namespace FutbolYa.WebAPI.Migrations
                     b.Navigation("UsuarioEstablecimiento");
                 });
 
-            modelBuilder.Entity("FutbolYa.WebAPI.Models.ReservaUsuario", b =>
-                {
-                    b.HasOne("FutbolYa.WebAPI.Models.Reserva", "Reserva")
-                        .WithMany("Jugadores")
-                        .HasForeignKey("ReservaId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.HasOne("FutbolYa.WebAPI.Models.Usuario", "Usuario")
-                        .WithMany()
-                        .HasForeignKey("UsuarioId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-
-                    b.Navigation("Reserva");
-
-                    b.Navigation("Usuario");
-                });
-
             modelBuilder.Entity("Partido", b =>
                 {
                     b.HasOne("FutbolYa.WebAPI.Models.Usuario", "Organizador")
@@ -463,11 +431,6 @@ namespace FutbolYa.WebAPI.Migrations
                     b.Navigation("Evaluador");
 
                     b.Navigation("Partido");
-                });
-
-            modelBuilder.Entity("FutbolYa.WebAPI.Models.Reserva", b =>
-                {
-                    b.Navigation("Jugadores");
                 });
 
             modelBuilder.Entity("FutbolYa.WebAPI.Models.Usuario", b =>

--- a/FutbolYa.WebAPI/Migrations/20250718013656_AddReservas.cs
+++ b/FutbolYa.WebAPI/Migrations/20250718013656_AddReservas.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FutbolYa.WebAPI.Migrations
+{
+    public partial class AddReservas : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Reservas",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    CanchaId = table.Column<int>(type: "int", nullable: false),
+                    FechaHora = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    DuracionMinutos = table.Column<int>(type: "int", nullable: false),
+                    ClienteNombre = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    ClienteTelefono = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    ClienteEmail = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    EsFrecuente = table.Column<bool>(type: "bit", nullable: false),
+                    EstadoPago = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Observaciones = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    UsuarioEstablecimientoId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Reservas", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Reservas_Canchas_CanchaId",
+                        column: x => x.CanchaId,
+                        principalTable: "Canchas",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_Reservas_Usuarios_UsuarioEstablecimientoId",
+                        column: x => x.UsuarioEstablecimientoId,
+                        principalTable: "Usuarios",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Reservas_CanchaId",
+                table: "Reservas",
+                column: "CanchaId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Reservas_UsuarioEstablecimientoId",
+                table: "Reservas",
+                column: "UsuarioEstablecimientoId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Reservas");
+        }
+    }
+}

--- a/FutbolYa.WebAPI/Migrations/20250718015211_AddReservaUsuarios.Designer.cs
+++ b/FutbolYa.WebAPI/Migrations/20250718015211_AddReservaUsuarios.Designer.cs
@@ -4,6 +4,7 @@ using FutbolYa.WebAPI.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace FutbolYa.WebAPI.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250718015211_AddReservaUsuarios")]
+    partial class AddReservaUsuarios
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/FutbolYa.WebAPI/Migrations/20250718015211_AddReservaUsuarios.cs
+++ b/FutbolYa.WebAPI/Migrations/20250718015211_AddReservaUsuarios.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FutbolYa.WebAPI.Migrations
+{
+    public partial class AddReservaUsuarios : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ReservaUsuarios",
+                columns: table => new
+                {
+                    ReservaId = table.Column<int>(type: "int", nullable: false),
+                    UsuarioId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ReservaUsuarios", x => new { x.ReservaId, x.UsuarioId });
+                    table.ForeignKey(
+                        name: "FK_ReservaUsuarios_Reservas_ReservaId",
+                        column: x => x.ReservaId,
+                        principalTable: "Reservas",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ReservaUsuarios_Usuarios_UsuarioId",
+                        column: x => x.UsuarioId,
+                        principalTable: "Usuarios",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReservaUsuarios_UsuarioId",
+                table: "ReservaUsuarios",
+                column: "UsuarioId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ReservaUsuarios");
+        }
+    }
+}

--- a/FutbolYa.WebAPI/Models/AppDbContext.cs
+++ b/FutbolYa.WebAPI/Models/AppDbContext.cs
@@ -13,6 +13,9 @@ namespace FutbolYa.WebAPI.Models
         public DbSet<Mensaje> Mensajes { get; set; }
         public DbSet<Rendimientos> Rendimientos { get; set; }
         public DbSet<Cancha> Canchas { get; set; }
+        public DbSet<Reserva> Reservas { get; set; }
+        public DbSet<ReservaUsuario> ReservaUsuarios { get; set; }
+
 
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -36,6 +39,27 @@ namespace FutbolYa.WebAPI.Models
                 .WithMany()
                 .HasForeignKey(r => r.EvaluadoId)
                 .OnDelete(DeleteBehavior.Restrict);
+
+            modelBuilder.Entity<Reserva>()
+                .HasOne(r => r.UsuarioEstablecimiento)
+                .WithMany()
+                .HasForeignKey(r => r.UsuarioEstablecimientoId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            modelBuilder.Entity<ReservaUsuario>()
+                .HasKey(ru => new { ru.ReservaId, ru.UsuarioId });
+
+            modelBuilder.Entity<ReservaUsuario>()
+                .HasOne(ru => ru.Reserva)
+                .WithMany(r => r.Jugadores)
+                .HasForeignKey(ru => ru.ReservaId);
+
+            modelBuilder.Entity<ReservaUsuario>()
+                .HasOne(ru => ru.Usuario)
+                .WithMany()
+                .HasForeignKey(ru => ru.UsuarioId)
+                .OnDelete(DeleteBehavior.Restrict);
+
         }
     }
 }

--- a/FutbolYa.WebAPI/Models/ReservaDTO.cs
+++ b/FutbolYa.WebAPI/Models/ReservaDTO.cs
@@ -1,0 +1,17 @@
+﻿namespace FutbolYa.WebAPI.Models
+{
+    public class ReservaDTO
+    {
+        public int CanchaId { get; set; }
+        public DateTime FechaHora { get; set; }
+        public int DuracionMinutos { get; set; }
+
+        public string ClienteNombre { get; set; }
+        public string ClienteTelefono { get; set; }
+        public string? ClienteEmail { get; set; }
+        public bool EsFrecuente { get; set; }
+
+        public string EstadoPago { get; set; }
+        public string? Observaciones { get; set; }
+    }
+}

--- a/FutbolYa.WebAPI/Models/ReservaUsuario.cs
+++ b/FutbolYa.WebAPI/Models/ReservaUsuario.cs
@@ -1,0 +1,14 @@
+﻿using System.Text.Json.Serialization;
+
+namespace FutbolYa.WebAPI.Models
+{
+    public class ReservaUsuario
+    {
+        public int ReservaId { get; set; }
+        [JsonIgnore]
+        public Reserva Reserva { get; set; }
+
+        public int UsuarioId { get; set; }
+        public Usuario Usuario { get; set; }
+    }
+}

--- a/FutbolYa.WebAPI/Models/Reservas.cs
+++ b/FutbolYa.WebAPI/Models/Reservas.cs
@@ -1,0 +1,38 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace FutbolYa.WebAPI.Models
+{
+    public class Reserva
+    {
+        public int Id { get; set; }
+
+        [Required]
+        public int CanchaId { get; set; }
+        public Cancha Cancha { get; set; }
+
+        [Required]
+        public DateTime FechaHora { get; set; } // Fecha + hora de inicio de la reserva
+
+        [Required]
+        public int DuracionMinutos { get; set; } // 60 minutos máximo
+
+        [Required]
+        public string ClienteNombre { get; set; }
+
+        [Required]
+        public string ClienteTelefono { get; set; }
+
+        public ICollection<ReservaUsuario> Jugadores { get; set; } = new List<ReservaUsuario>();
+
+        public string? ClienteEmail { get; set; }
+        public bool EsFrecuente { get; set; }
+
+        public string EstadoPago { get; set; } // Pagado / Pendiente / Seña
+        public string? Observaciones { get; set; }
+
+        public int UsuarioEstablecimientoId { get; set; }
+        [JsonIgnore]
+        public Usuario UsuarioEstablecimiento { get; set; }
+    }
+}


### PR DESCRIPTION
…rol por rol)

✅ Funcionalidades agregadas:
- Crear reservas (jugador o establecimiento)
- Establecimientos pueden gestionar reservas (ver, editar, cancelar, ver agenda semanal o diaria)
- Unirse a reservas (solo si hay lugar según tipo de cancha)
- Vista por cancha y agenda semanal para establecimientos
- Restricciones por rol y validaciones de tiempo, solapamientos y capacidad